### PR TITLE
find_in_files_goto

### DIFF
--- a/FindResultsApplyChanges.py
+++ b/FindResultsApplyChanges.py
@@ -104,3 +104,37 @@ class FindResultsApplyChangesCommand(sublime_plugin.WindowCommand):
 
 	def write(self, f, c):
 		open(f, 'w+', encoding='utf8', newline='').write(str(c))
+
+class FindInFilesGotoCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        view = self.view
+        if view.name() == "Find Results":
+            line_no = self.get_line_no()
+            file_name = self.get_file()
+            if line_no is not None and file_name is not None:
+                file_loc = "%s:%s" % (file_name, line_no)
+                view.window().open_file(file_loc, sublime.ENCODED_POSITION)
+            elif file_name is not None:
+                view.window().open_file(file_name)
+
+    def get_line_no(self):
+        view = self.view
+        if len(view.sel()) == 1:
+            line_text = view.substr(view.line(view.sel()[0]))
+            match = re.match(r"\s*(\d+).+", line_text)
+            if match:
+                return match.group(1)
+        return None
+
+    def get_file(self):
+        view = self.view
+        if len(view.sel()) == 1:
+            line = view.line(view.sel()[0])
+            while line.begin() > 0:
+                line_text = view.substr(line)
+                match = re.match(r"(.+):$", line_text)
+                if match:
+                    if os.path.exists(match.group(1)):
+                        return match.group(1)
+                line = view.line(line.begin() - 1)
+        return None

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,20 @@ Apply any change you made to a "Find Results" buffer back to the files. ie:
 - This will write all the changes made back to the files.
 - Will be enabled only if the focused view is the "Find Results" tab.
 
+### Keyboard Shortcuts
+Specify a key command to open a file from the "Find Results" butter using the keyboard (equivalent to Sublime's default double-click behavior). Add the following to your keyboard settings file, ST3/Packages/User/Default (SYSTEM).sublime-keymap:
+
+	{
+		"keys": ["super+alt+o"],
+		"command": "find_in_files_goto",
+		"context": [{
+				"key": "selector",
+				"operator": "equal",
+				"operand": "text.find-in-files"
+		}]
+	}
+
+
 ## Bugs
 
 - Uses regions to allow you do multiline changes, but when inserting new newlines, will corrupt files **if you commit more than once**, this because the new newlines will shift the line numbers. Will also 'corrupt' files if you add/remove newlines in other instances of the modified files. eg in another tab. To prevent corruption this packages will alert you and prevent most of these.


### PR DESCRIPTION
Add find_in_files_goto which allows you to open a file from the "Find Files" buffer using a keyboard shortcut.

See http://stackoverflow.com/questions/16767732/sublime-text-how-to-jump-to-file-from-find-results-using-keyboard
